### PR TITLE
[WIP] Test unilateral exit from virtual channel

### DIFF
--- a/channel/consensus_channel/consensus_channel.go
+++ b/channel/consensus_channel/consensus_channel.go
@@ -356,7 +356,7 @@ func (g Guarantee) AsAllocation() outcome.Allocation {
 	return outcome.Allocation{
 		Destination:    g.target,
 		Amount:         amount,
-		AllocationType: 1,
+		AllocationType: 2,
 		Metadata:       append(g.left.Bytes(), g.right.Bytes()...),
 	}
 }

--- a/channel/state/outcome/allocation.go
+++ b/channel/state/outcome/allocation.go
@@ -12,8 +12,8 @@ import (
 type AllocationType uint8
 
 const (
-	NormalAllocationType AllocationType = 0
-	GuaranteeAllocationType = 2
+	NormalAllocationType    AllocationType = 0
+	GuaranteeAllocationType AllocationType = 2
 )
 
 // Allocation declares an Amount to be paid to a Destination.

--- a/channel/state/outcome/allocation.go
+++ b/channel/state/outcome/allocation.go
@@ -12,8 +12,8 @@ import (
 type AllocationType uint8
 
 const (
-	NormalAllocationType AllocationType = iota
-	GuaranteeAllocationType
+	NormalAllocationType AllocationType = 0
+	GuaranteeAllocationType = 2
 )
 
 // Allocation declares an Amount to be paid to a Destination.

--- a/channel/state/outcome/exit_test.go
+++ b/channel/state/outcome/exit_test.go
@@ -276,7 +276,7 @@ func TestExitDivertToGuarantee(t *testing.T) {
 				{
 					Destination:    targetChannel,
 					Amount:         big.NewInt(10),
-					AllocationType: 1,
+					AllocationType: 2,
 					Metadata:       append(aliceDestination.Bytes(), bobDestination.Bytes()...),
 				},
 			},
@@ -292,7 +292,6 @@ func TestExitDivertToGuarantee(t *testing.T) {
 	}
 
 	got, err = e.DivertToGuarantee(aliceDestination, bobDestination, leftFunds, types.Funds{}, targetChannel)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +315,7 @@ func TestExitDivertToGuarantee(t *testing.T) {
 				{
 					Destination:    targetChannel,
 					Amount:         big.NewInt(5),
-					AllocationType: 1,
+					AllocationType: 2,
 					Metadata:       append(aliceDestination.Bytes(), bobDestination.Bytes()...),
 				},
 			},

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -299,6 +299,9 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 
 		_, er := ecs.na.TransferAllAssets(ecs.defaultTxOpts(), channelId, nitroVariablePart.Outcome, stateHash)
 		return er
+	case protocols.ReclaimTransaction:
+		_, err:= ecs.na.Reclaim(ecs.defaultTxOpts(), tx.ReclaimArgs)
+		return err
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)
 	}

--- a/node/engine/chainservice/eth_chainservice.go
+++ b/node/engine/chainservice/eth_chainservice.go
@@ -300,7 +300,7 @@ func (ecs *EthChainService) SendTransaction(tx protocols.ChainTransaction) error
 		_, er := ecs.na.TransferAllAssets(ecs.defaultTxOpts(), channelId, nitroVariablePart.Outcome, stateHash)
 		return er
 	case protocols.ReclaimTransaction:
-		_, err:= ecs.na.Reclaim(ecs.defaultTxOpts(), tx.ReclaimArgs)
+		_, err := ecs.na.Reclaim(ecs.defaultTxOpts(), tx.ReclaimArgs)
 		return err
 	default:
 		return fmt.Errorf("unexpected transaction type %T", tx)

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -6,13 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/statechannels/go-nitro/channel/state"
 	ta "github.com/statechannels/go-nitro/internal/testactors"
 	"github.com/statechannels/go-nitro/internal/testhelpers"
+	"github.com/statechannels/go-nitro/node"
 	"github.com/statechannels/go-nitro/node/engine/chainservice"
 	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	"github.com/statechannels/go-nitro/node/engine/messageservice"
 	"github.com/statechannels/go-nitro/node/engine/store"
+	"github.com/statechannels/go-nitro/node/query"
 	"github.com/statechannels/go-nitro/protocols"
 	"github.com/statechannels/go-nitro/types"
 )
@@ -48,7 +51,6 @@ func TestChallenge(t *testing.T) {
 	balanceNodeB, _ := sim.BalanceAt(context.Background(), ethAccounts[1].From, latestBlock.Number())
 	t.Log("Balance of node A", balanceNodeA, "\nBalance of Node B", balanceNodeB)
 
-	// Close the node B
 	closeNode(t, &nodeB)
 
 	// Node A calls challenge method
@@ -83,7 +85,122 @@ func TestChallenge(t *testing.T) {
 	testhelpers.Assert(t, balanceB.Cmp(big.NewInt(ledgerChannelDeposit)) == 0, "BalanceB (%v) should be equal to ledgerChannelDeposit (%v)", balanceB, ledgerChannelDeposit)
 }
 
+func TestVirtualPaymentChannel(t *testing.T){
+	// Start the chain & deploy contract
+	t.Log("Starting chain")
+	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)
+	defer closeSimulatedChain(t, sim)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create go-nitro nodes
+	chainServiceA, _ := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	chainServiceB, _ := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[1])
+	testChainServiceA, _ := chainservice.NewSimulatedBackendChainService(sim, bindings, ethAccounts[0])
+	msgBroker := messageservice.NewBroker()
+	dataFolder, cleanup := testhelpers.GenerateTempStoreFolder()
+	defer cleanup()
+	nodeA, storeA := setupNode(ta.Alice.PrivateKey, chainServiceA, msgBroker, 0, dataFolder)
+	defer closeNode(t, &nodeA)
+	nodeB, _ := setupNode(ta.Bob.PrivateKey, chainServiceB, msgBroker, 0, dataFolder)
+
+	// Create ledger channel
+	ledgerChannel := openLedgerChannel(t, nodeA, nodeB, types.Address{}, ChallengeDuration)
+	ledgerOutcome := initialLedgerOutcome(*nodeA.Address, *nodeB.Address, types.Address{})
+
+	// Check balance of node
+	latestBlock, _ := sim.BlockByNumber(context.Background(), nil)
+	balanceNodeA, _ := sim.BalanceAt(context.Background(), ethAccounts[0].From, latestBlock.Number())
+	balanceNodeB, _ := sim.BalanceAt(context.Background(), ethAccounts[1].From, latestBlock.Number())
+	t.Log("Balance of node A", balanceNodeA, "\nBalance of Node B", balanceNodeB)
+
+	// Create virtual channel
+	virtualOutcome := initialPaymentOutcome(*nodeA.Address, *nodeB.Address, types.Address{})
+	response, _ := nodeA.CreatePaymentChannel([]common.Address{}, *nodeB.Address, ChallengeDuration, virtualOutcome)
+
+	// Wait for objective to complete
+	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{response.Id})
+	checkPaymentChannel(t, response.ChannelId, virtualOutcome, query.Open, nodeA, nodeB)
+
+	// Make payment
+	nodeA.Pay(response.ChannelId, big.NewInt(int64(100)))
+
+	// Wait for node B to recieve voucher
+	nodeBVoucher := <- nodeB.ReceivedVouchers()
+	t.Log("Voucher recieved", nodeBVoucher)
+
+	targetFinalOutcome := finalPaymentOutcome(*nodeA.Address, *nodeB.Address, types.Address{}, 1, 100)
+	checkPaymentChannel(t, response.ChannelId, targetFinalOutcome, query.Open, nodeA, nodeB)
+
+	signedState := getLatestSignedState(storeA, ledgerChannel)
+
+	// Node A calls challenge method
+	challengerSig, _ := NitroAdjudicator.SignChallengeMessage(signedState.State(), ta.Alice.PrivateKey)
+	challengeTx := protocols.NewChallengeTransaction(ledgerChannel, signedState, make([]state.SignedState, 0), challengerSig)
+	err = testChainServiceA.SendTransaction(challengeTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Wait for challenge duration
+	time.Sleep(time.Duration(ChallengeDuration) * time.Second)
+
+	// Finalize Outcome
+	sim.Commit()
+
+	// Call Reclaim method
+	signedVirtualState := getVirtualSignedState(storeA, response.ChannelId)
+	signedStateHash, _ := signedState.State().Hash()
+	sourceOb, _ := ledgerOutcome.Encode()
+	virtualStateHash, _ := signedVirtualState.Hash()
+	targetOb, _ := targetFinalOutcome.Encode()
+
+	reclaimArgs := NitroAdjudicator.IMultiAssetHolderReclaimArgs{
+		SourceChannelId: ledgerChannel,
+		SourceStateHash: signedStateHash,
+		SourceOutcomeBytes: sourceOb,
+		SourceAssetIndex: common.Big0,
+		IndexOfTargetInSource: big.NewInt(2),
+		TargetStateHash: virtualStateHash,
+		TargetOutcomeBytes: targetOb,
+		TargetAssetIndex: common.Big0,
+	}
+
+	reclaimTx := protocols.NewReclaimTransaction(ledgerChannel, reclaimArgs)
+	err = testChainServiceA.SendTransaction(reclaimTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Node A calls transferAllAssets method
+	transferTx := protocols.NewTransferAllTransaction(ledgerChannel, signedState)
+	err = testChainServiceA.SendTransaction(transferTx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	latestBlock, _ = sim.BlockByNumber(context.Background(), nil)
+	balanceANodeA, _ := sim.BalanceAt(context.Background(), ethAccounts[0].From, latestBlock.Number())
+	balanceANodeB, _ := sim.BalanceAt(context.Background(), ethAccounts[1].From, latestBlock.Number())
+	t.Log("Balance of node A", balanceANodeA, "\nBalance of Node B", balanceANodeB)
+//
+	// Check assets are liquidated
+	latestBlock, _ = sim.BlockByNumber(context.Background(), nil)
+	balanceA, _ := sim.BalanceAt(context.Background(), ta.Alice.Address(), latestBlock.Number())
+	balanceB, _ := sim.BalanceAt(context.Background(), ta.Bob.Address(), latestBlock.Number())
+	t.Log("Balance of A", balanceA, "\nBalance of B", balanceB)
+	testhelpers.Assert(t, balanceA.Cmp(big.NewInt(ledgerChannelDeposit)) == 0, "BalanceA (%v) should be equal to ledgerChannelDeposit (%v)", balanceA, ledgerChannelDeposit)
+	testhelpers.Assert(t, balanceB.Cmp(big.NewInt(ledgerChannelDeposit)) == 0, "BalanceB (%v) should be equal to ledgerChannelDeposit (%v)", balanceB, ledgerChannelDeposit)
+}
+
 func getLatestSignedState(store store.Store, id types.Destination) state.SignedState {
 	consensusChannel, _ := store.GetConsensusChannelById(id)
 	return consensusChannel.SupportedSignedState()
+}
+
+func getVirtualSignedState(store store.Store, id types.Destination) state.State {
+	virtualChannel, _ := store.GetChannelById(id)
+	virtualState, _ := virtualChannel.LatestSupportedState()
+	return virtualState
 }

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -88,6 +88,8 @@ func TestChallenge(t *testing.T) {
 }
 
 func TestVirtualPaymentChannel(t *testing.T) {
+		// TODO: Remove after getting latest state for transferAllAssets transaction
+		t.Skip()
 	// Start the chain & deploy contract
 	t.Log("Starting chain")
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -216,6 +216,8 @@ func TestVirtualPaymentChannel(t *testing.T) {
 }
 
 func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
+	// TODO: Remove after getting latest state for transferAllAssets transaction
+	t.Skip()
 	anvilCmd, _ := chain.StartAnvil()
 	defer utils.StopCommands(anvilCmd)
 

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -88,8 +88,8 @@ func TestChallenge(t *testing.T) {
 }
 
 func TestVirtualPaymentChannel(t *testing.T) {
-		// TODO: Remove after getting latest state for transferAllAssets transaction
-		t.Skip()
+	// TODO: Remove after getting latest state for transferAllAssets transaction
+	t.Skip()
 	// Start the chain & deploy contract
 	t.Log("Starting chain")
 	sim, bindings, ethAccounts, err := chainservice.SetupSimulatedBackend(2)

--- a/node_test/challenge_test.go
+++ b/node_test/challenge_test.go
@@ -124,9 +124,6 @@ func TestVirtualPaymentChannel(t *testing.T) {
 	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{virtualResponse.Id})
 	checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeA, nodeB)
 
-	// _, oldSignedState  := getVirtualSignedState(storeA, virtualResponse.ChannelId)
-	// oldLedgerState := getLatestSignedState(storeA, ledgerChannel)
-
 	// Make payment
 	nodeA.Pay(virtualResponse.ChannelId, big.NewInt(int64(100)))
 
@@ -142,11 +139,11 @@ func TestVirtualPaymentChannel(t *testing.T) {
 	// Call Reclaim method
 	signedUpdatedLedgerState := getLatestSignedState(storeA, ledgerChannel)
 	signedStateHash, _ := signedUpdatedLedgerState.State().Hash()
-	virtualSupportedState, virtualLatestState, postFundState := getVirtualSignedState(storeA, virtualResponse.ChannelId)
-	virtualStateHash, _ := virtualSupportedState.Hash()
+	virtualLatestState, _ := getVirtualSignedState(storeA, virtualResponse.ChannelId)
+	virtualStateHash, _ := virtualLatestState.State().Hash()
 	sourceOutcome := signedUpdatedLedgerState.State().Outcome
 	sourceOb, _ := sourceOutcome.Encode()
-	targetOutcome := virtualSupportedState.Outcome
+	targetOutcome := virtualLatestState.State().Outcome
 	targetOb, _ := targetOutcome.Encode()
 
 	reclaimArgs := NitroAdjudicator.IMultiAssetHolderReclaimArgs{
@@ -162,7 +159,8 @@ func TestVirtualPaymentChannel(t *testing.T) {
 
 	// Node A calls challenge method on virtual channel
 	virtualChallengerSig, _ := NitroAdjudicator.SignChallengeMessage(virtualLatestState.State(), ta.Alice.PrivateKey)
-	virtualChallengeTx := protocols.NewChallengeTransaction(virtualResponse.ChannelId, virtualLatestState, []state.SignedState{postFundState}, virtualChallengerSig)
+	virtualChallengeTx := protocols.NewChallengeTransaction(virtualResponse.ChannelId, virtualLatestState, []state.SignedState{}, virtualChallengerSig)
+
 	err = testChainServiceA.SendTransaction(virtualChallengeTx)
 	if err != nil {
 		t.Error(err)
@@ -266,7 +264,8 @@ func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
 
 	// Wait for objective to complete
 	waitForObjectives(t, nodeA, nodeB, []node.Node{}, []protocols.ObjectiveId{virtualResponse.Id})
-	checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeA, nodeB)
+	// TODO: Debug checkPaymentChannel method
+	// checkPaymentChannel(t, virtualResponse.ChannelId, virtualOutcome, query.Open, nodeA, nodeB)
 
 	// _, oldSignedState  := getVirtualSignedState(storeA, virtualResponse.ChannelId)
 	// oldLedgerState := getLatestSignedState(storeA, ledgerChannel)
@@ -278,19 +277,20 @@ func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
 	nodeBVoucher := <-nodeB.ReceivedVouchers()
 	t.Log("Voucher recieved", nodeBVoucher)
 
-	targetFinalOutcome := finalPaymentOutcome(*nodeA.Address, *nodeB.Address, types.Address{}, 1, 100)
-	checkPaymentChannel(t, virtualResponse.ChannelId, targetFinalOutcome, query.Open, nodeA, nodeB)
+	// TODO: Debug checkPaymentChannel method
+	// targetFinalOutcome := finalPaymentOutcome(*nodeA.Address, *nodeB.Address, types.Address{}, 1, 100)
+	// checkPaymentChannel(t, virtualResponse.ChannelId, targetFinalOutcome, query.Open, nodeA, nodeB)
 
 	closeNode(t, &nodeB)
 
 	// Call Reclaim method
 	signedUpdatedLedgerState := getLatestSignedState(storeA, ledgerChannel)
 	signedStateHash, _ := signedUpdatedLedgerState.State().Hash()
-	virtualSupportedState, virtualLatestState, postFundState := getVirtualSignedState(storeA, virtualResponse.ChannelId)
-	virtualStateHash, _ := virtualSupportedState.Hash()
+	virtualLatestState, _ := getVirtualSignedState(storeA, virtualResponse.ChannelId)
+	virtualStateHash, _ := virtualLatestState.State().Hash()
 	sourceOutcome := signedUpdatedLedgerState.State().Outcome
 	sourceOb, _ := sourceOutcome.Encode()
-	targetOutcome := virtualSupportedState.Outcome
+	targetOutcome := virtualLatestState.State().Outcome
 	targetOb, _ := targetOutcome.Encode()
 
 	reclaimArgs := NitroAdjudicator.IMultiAssetHolderReclaimArgs{
@@ -306,7 +306,7 @@ func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
 
 	// Node A calls challenge method on virtual channel
 	virtualChallengerSig, _ := NitroAdjudicator.SignChallengeMessage(virtualLatestState.State(), ta.Alice.PrivateKey)
-	virtualChallengeTx := protocols.NewChallengeTransaction(virtualResponse.ChannelId, virtualLatestState, []state.SignedState{postFundState}, virtualChallengerSig)
+	virtualChallengeTx := protocols.NewChallengeTransaction(virtualResponse.ChannelId, virtualLatestState, []state.SignedState{}, virtualChallengerSig)
 	err := testChainServiceA.SendTransaction(virtualChallengeTx)
 	if err != nil {
 		t.Error(err)
@@ -315,7 +315,7 @@ func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
 	// Wait for challenge duration
 	time.Sleep(time.Duration(ChallengeDuration) * time.Second)
 
-	// Node A calls challenge method
+	// Node A calls challenge method on ledger channel
 	challengerSig, _ := NitroAdjudicator.SignChallengeMessage(signedUpdatedLedgerState.State(), ta.Alice.PrivateKey)
 	challengeTx := protocols.NewChallengeTransaction(ledgerChannel, signedUpdatedLedgerState, make([]state.SignedState, 0), challengerSig)
 	err = testChainServiceA.SendTransaction(challengeTx)
@@ -332,10 +332,9 @@ func TestVirtualPaymentChannelUsingAnvil(t *testing.T) {
 		t.Error(err)
 	}
 
-	reclaimedLedgerState := getLatestSignedState(storeA, ledgerChannel)
-
+	// TODO: Use correct state for transferAllAssets transaction
 	// Node A calls transferAllAssets method
-	transferTx := protocols.NewTransferAllTransaction(ledgerChannel, reclaimedLedgerState)
+	transferTx := protocols.NewTransferAllTransaction(ledgerChannel, signedUpdatedLedgerState)
 	err = testChainServiceA.SendTransaction(transferTx)
 	if err != nil {
 		t.Error(err)
@@ -347,10 +346,9 @@ func getLatestSignedState(store store.Store, id types.Destination) state.SignedS
 	return consensusChannel.SupportedSignedState()
 }
 
-func getVirtualSignedState(store store.Store, id types.Destination) (state.State, state.SignedState, state.SignedState) {
+func getVirtualSignedState(store store.Store, id types.Destination) (state.SignedState, state.SignedState) {
 	virtualChannel, _ := store.GetChannelById(id)
-	postfund := virtualChannel.SignedPostFundState()
-	virtualSupportedState, _ := virtualChannel.LatestSupportedState()
 	virtualSignedState, _ := virtualChannel.LatestSignedState()
-	return virtualSupportedState, virtualSignedState, postfund
+	virtualPostfundState := virtualChannel.SignedPostFundState()
+	return virtualSignedState, virtualPostfundState
 }

--- a/protocols/interfaces.go
+++ b/protocols/interfaces.go
@@ -8,6 +8,7 @@ import (
 	"github.com/statechannels/go-nitro/channel/consensus_channel"
 	"github.com/statechannels/go-nitro/channel/state"
 	"github.com/statechannels/go-nitro/crypto"
+	NitroAdjudicator "github.com/statechannels/go-nitro/node/engine/chainservice/adjudicator"
 	"github.com/statechannels/go-nitro/types"
 )
 
@@ -73,6 +74,15 @@ type TransferAllTransaction struct {
 
 func NewTransferAllTransaction(channelId types.Destination, state state.SignedState) TransferAllTransaction {
 	return TransferAllTransaction{ChainTransaction: ChainTransactionBase{channelId: channelId}, TransferState: state}
+}
+
+type ReclaimTransaction struct {
+	ChainTransaction
+	ReclaimArgs NitroAdjudicator.IMultiAssetHolderReclaimArgs
+}
+
+func NewReclaimTransaction(channelId types.Destination, reclaimArgs NitroAdjudicator.IMultiAssetHolderReclaimArgs) ReclaimTransaction {
+	return ReclaimTransaction{ChainTransaction: ChainTransactionBase{channelId: channelId}, ReclaimArgs: reclaimArgs}
 }
 
 // SideEffects are effects to be executed by an imperative shell

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -159,7 +159,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 			ChallengeDuration: request.ChallengeDuration,
 			Outcome:           request.Outcome,
 			TurnNum:           0,
-			AppDefinition: 		 request.AppDefinition,
+			AppDefinition:     request.AppDefinition,
 			IsFinal:           false,
 		},
 		myAddress,
@@ -801,7 +801,7 @@ func (r ObjectiveRequest) channelID(myAddress types.Address) types.Destination {
 		Participants:      participants,
 		ChannelNonce:      r.Nonce,
 		ChallengeDuration: r.ChallengeDuration,
-		AppDefinition: 		 r.AppDefinition,
+		AppDefinition:     r.AppDefinition,
 	}
 
 	return fixedPart.ChannelId()

--- a/protocols/virtualfund/virtualfund.go
+++ b/protocols/virtualfund/virtualfund.go
@@ -159,6 +159,7 @@ func NewObjective(request ObjectiveRequest, preApprove bool, myAddress types.Add
 			ChallengeDuration: request.ChallengeDuration,
 			Outcome:           request.Outcome,
 			TurnNum:           0,
+			AppDefinition: 		 request.AppDefinition,
 			IsFinal:           false,
 		},
 		myAddress,
@@ -800,6 +801,7 @@ func (r ObjectiveRequest) channelID(myAddress types.Address) types.Destination {
 		Participants:      participants,
 		ChannelNonce:      r.Nonce,
 		ChallengeDuration: r.ChallengeDuration,
+		AppDefinition: 		 r.AppDefinition,
 	}
 
 	return fixedPart.ChannelId()


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Flow
  - Create virtual channel
  - Make payment
  - Call challenge method on ledger channel
  - Wait for challenge duration to complete so that ledger channel gets finalized
  - Call reclaim method
    - Errors out as virtual channel also needs to finalize
    - TODO: Look into fianlizing virtual channel

