### PR TITLE
Revert change to remove default TLS cert in go-nitro node CLI

### DIFF
--- a/cmd/start-rpc-servers/main.go
+++ b/cmd/start-rpc-servers/main.go
@@ -192,9 +192,6 @@ func setupRPCServer(n name, c color, na, vpa, ca types.Address, chainUrl, chainA
 
 	args = append(args, "-durablestorefolder", dataFolder)
 
-	args = append(args, "-tlscertfilepath", "./tls/statechannels.org.pem")
-	args = append(args, "-tlskeyfilepath", "./tls/statechannels.org_key.pem")
-
 	args = append(args, "-config", fmt.Sprintf("./cmd/test-configs/%s.toml", n))
 
 	cmd := exec.Command("go", args...)

--- a/cmd/test-configs/alice.toml
+++ b/cmd/test-configs/alice.toml
@@ -3,7 +3,7 @@
 usedurablestore = true
 
 msgport = 3005
-wsmsgport = 5005
+wsmsgport = 6005
 rpcport = 4005
 guiport = 5005
 

--- a/cmd/test-configs/bob.toml
+++ b/cmd/test-configs/bob.toml
@@ -4,7 +4,7 @@ usedurablestore = true
 
 guiport = 5007
 msgport = 3007
-wsmsgport = 5007
+wsmsgport = 6007
 rpcport = 4007
 
 # PeerID: 16Uiu2HAmJDxLM8rSybX78FH51iZq9PdrwCoCyyHRBCndNzcAYMes

--- a/cmd/test-configs/irene.toml
+++ b/cmd/test-configs/irene.toml
@@ -4,7 +4,7 @@ usedurablestore = true
 
 guiport = 5006
 msgport = 3006
-wsmsgport = 5006
+wsmsgport = 6006
 rpcport = 4006
 
 # PeerID: 16Uiu2HAmHntR3SGeS7iF2tdeNBefSahXBhmTrqVozVLHydxzkaZn

--- a/doc.go
+++ b/doc.go
@@ -25,7 +25,7 @@
 //	-msgport int
 //	      Specifies the tcp port for the  message service. (default 3005)
 //	-wsmsgport int
-//				Specifies the websocket port for the  message service. (default 5005)
+//				Specifies the websocket port for the  message service. (default 6005)
 //	-naaddress string
 //	      Specifies the address of the nitro adjudicator contract. Default is the address computed by the Create2Deployer contract. (default "0xC6A55E07566416274dBF020b5548eecEdB56290c")
 //	-pk string

--- a/internal/testactors/actors.go
+++ b/internal/testactors/actors.go
@@ -28,7 +28,7 @@ func (a Actor) Address() types.Address {
 
 const (
 	START_PORT    = 3200
-	WS_START_PORT = 5200
+	WS_START_PORT = 6200
 )
 
 // Alice has the address 0xAAA6628Ec44A8a742987EF3A114dDFE2D4F7aDCE

--- a/main.go
+++ b/main.go
@@ -225,12 +225,14 @@ func main() {
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        TLS_CERT_FILEPATH,
 			Usage:       "Filepath to the TLS certificate. If not specified, TLS will not be used with the RPC transport.",
+			Value:       "./tls/statechannels.org.pem",
 			Category:    TLS_CATEGORY,
 			Destination: &tlsCertFilepath,
 		}),
 		altsrc.NewStringFlag(&cli.StringFlag{
 			Name:        TLS_KEY_FILEPATH,
 			Usage:       "Filepath to the TLS private key. If not specified, TLS will not be used with the RPC transport.",
+			Value:       "./tls/statechannels.org_key.pem",
 			Category:    TLS_CATEGORY,
 			Destination: &tlsKeyFilepath,
 		}),

--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func main() {
 		altsrc.NewIntFlag(&cli.IntFlag{
 			Name:        WS_MSG_PORT,
 			Usage:       "Specifies the websocket port for the message service.",
-			Value:       5005,
+			Value:       6005,
 			Category:    "Connectivity:",
 			Destination: &wsMsgPort,
 		}),

--- a/node/engine/messageservice/p2p-message-service/service.go
+++ b/node/engine/messageservice/p2p-message-service/service.go
@@ -116,7 +116,6 @@ func NewMessageService(opts MessageOpts) *P2PMessageService {
 		libp2p.NATPortMap(),
 		libp2p.EnableNATService(),
 		libp2p.Transport(websocket.New),
-		// libp2p.NoSecurity, // Use default security options (Noise + TLS)
 		libp2p.DefaultMuxers,
 	}
 	host, err := libp2p.New(options...)

--- a/node_test/paymentproxy_test.go
+++ b/node_test/paymentproxy_test.go
@@ -238,11 +238,11 @@ func setupNitroClients(t *testing.T, logFile string) (alice, irene, bob rpc.RpcC
 	aliceChainService := chainservice.NewMockChainService(chain, ta.Alice.Address())
 	bobChainService := chainservice.NewMockChainService(chain, ta.Bob.Address())
 	ireneChainService := chainservice.NewMockChainService(chain, ta.Irene.Address())
-	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 5106, 4106, ireneChainService, transport.Http, []string{})
+	ireneClient, msgIrene, ireneCleanup := setupNitroNodeWithRPCClient(t, ta.Irene.PrivateKey, 3106, 6106, 4106, ireneChainService, transport.Http, []string{})
 	bootPeers := []string{msgIrene.MultiAddr}
-	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 5105, 4105, aliceChainService, transport.Http, bootPeers)
+	aliceClient, msgAlice, aliceCleanup := setupNitroNodeWithRPCClient(t, ta.Alice.PrivateKey, 3105, 6105, 4105, aliceChainService, transport.Http, bootPeers)
 
-	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 5107, 4107, bobChainService, transport.Http, bootPeers)
+	bobClient, msgBob, bobCleanup := setupNitroNodeWithRPCClient(t, ta.Bob.PrivateKey, 3107, 6107, 4107, bobChainService, transport.Http, bootPeers)
 
 	slog.Info("Clients created")
 

--- a/node_test/rpc_test.go
+++ b/node_test/rpc_test.go
@@ -115,7 +115,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 	// Set up the intermediaries
 	if n > 2 {
 		for i := 1; i < n-1; i++ {
-			rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 5105+i, 4105+i, chainServices[i], connectionType, []string{})
+			rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 6105+i, 4105+i, chainServices[i], connectionType, []string{})
 			clients[i] = rpcClient
 			msgServices[i] = msg
 			bootPeers = append(bootPeers, msg.MultiAddr)
@@ -125,7 +125,7 @@ func executeNRpcTest(t *testing.T, connectionType transport.TransportType, n int
 
 	// Set up the first and last client
 	for i := 0; i < n; i = i + (n - 1) {
-		rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 5105+i, 4105+i, chainServices[i], connectionType, bootPeers)
+		rpcClient, msg, cleanup := setupNitroNodeWithRPCClient(t, actors[i].PrivateKey, 3105+i, 6105+i, 4105+i, chainServices[i], connectionType, bootPeers)
 		clients[i] = rpcClient
 		msgServices[i] = msg
 		defer cleanup()

--- a/packages/nitro-protocol/hardhat-deploy/deploy-fvm.ts
+++ b/packages/nitro-protocol/hardhat-deploy/deploy-fvm.ts
@@ -1,23 +1,18 @@
 import 'hardhat-deploy';
 import 'hardhat-deploy-ethers';
-import fs from 'fs';
-import path from 'path';
 
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 
 module.exports = async (hre: HardhatRuntimeEnvironment) => {
-  const {deployments, getNamedAccounts, getChainId, ethers, network} = hre;
+  const {deployments, getNamedAccounts, getChainId, ethers} = hre;
   const {deploy} = deployments;
   const {deployer} = await getNamedAccounts();
-
-  const addressesFilePath = `hardhat-deployments/${network.name}/.contracts.env`;
-  let contractAddresses = '';
 
   console.log('Working on chain id #', await getChainId());
   console.log('deployer', deployer);
 
   try {
-    const deployResult = await deploy('NitroAdjudicator', {
+    await deploy('NitroAdjudicator', {
       from: deployer,
       args: [],
       // since Ethereum's legacy transaction format is not supported on FVM, we need to specify
@@ -27,14 +22,13 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
       skipIfAlreadyDeployed: false,
       log: true,
     });
-    contractAddresses = `${contractAddresses}NA_ADDRESS=${deployResult.address}\n`;
   } catch (err) {
     const msg = err instanceof Error ? err.message : JSON.stringify(err);
     console.error(`Error when deploying contract: ${msg}`);
   }
 
   try {
-    const deployResult = await deploy('ConsensusApp', {
+    await deploy('ConsensusApp', {
       from: deployer,
       args: [],
       // since Ethereum's legacy transaction format is not supported on FVM, we need to specify
@@ -44,14 +38,13 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
       skipIfAlreadyDeployed: false,
       log: true,
     });
-    contractAddresses = `${contractAddresses}CA_ADDRESS=${deployResult.address}\n`;
   } catch (err) {
     const msg = err instanceof Error ? err.message : JSON.stringify(err);
     console.error(`Error when deploying contract: ${msg}`);
   }
 
   try {
-    const deployResult = await deploy('VirtualPaymentApp', {
+    await deploy('VirtualPaymentApp', {
       from: deployer,
       args: [],
       // since Ethereum's legacy transaction format is not supported on FVM, we need to specify
@@ -61,14 +54,9 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
       skipIfAlreadyDeployed: false,
       log: true,
     });
-    contractAddresses = `${contractAddresses}VPA_ADDRESS=${deployResult.address}\n`;
   } catch (err) {
     const msg = err instanceof Error ? err.message : JSON.stringify(err);
     console.error(`Error when deploying contract: ${msg}`);
   }
-
-  const outputFilePath = path.resolve(addressesFilePath);
-  fs.writeFileSync(outputFilePath, contractAddresses);
-  console.log('Contracts deployed, addresses written to', outputFilePath);
 };
 module.exports.tags = ['deploy-fvm'];

--- a/packages/nitro-protocol/package.json
+++ b/packages/nitro-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statechannels/nitro-protocol",
-  "version": "2.0.1-alpha.6",
+  "version": "2.1.0-alpha.0",
   "description": "Smart contracts and typescript libraries for nitro state channel protocol.",
   "keywords": [],
   "homepage": "https://github.com/statechannels/go-nitro",

--- a/paymentproxy/proxy.go
+++ b/paymentproxy/proxy.go
@@ -59,7 +59,7 @@ type PaymentProxy struct {
 	enablePaidRpcMethods      bool
 }
 
-// NewReversePaymentProxy creates a new ReversePaymentProxy.
+// NewPaymentProxy creates a new PaymentProxy.
 func NewPaymentProxy(proxyAddress string, nitroEndpoint string, destinationURL string, costPerByte uint64, certFilePath, certKeyPath string, enablePaidRpcMethods bool) *PaymentProxy {
 	server := &http.Server{Addr: proxyAddress}
 

--- a/rpc/node-server.go
+++ b/rpc/node-server.go
@@ -47,15 +47,15 @@ func newNodeRpcServerWithoutNotifications(nitroNode *nitro.Node, trans transport
 	return nrs, nil
 }
 
-func NewNodeRpcServer(node *nitro.Node, paymentManager paymentsmanager.PaymentsManager, trans transport.Responder) (*NodeRpcServer, error) {
+func NewNodeRpcServer(nitroNode *nitro.Node, paymentManager paymentsmanager.PaymentsManager, trans transport.Responder) (*NodeRpcServer, error) {
 	baseRpcServer := NewBaseRpcServer(trans)
 	nrs := &NodeRpcServer{
-		baseRpcServer,
-		node,
-		paymentManager,
+		BaseRpcServer:  baseRpcServer,
+		node:           nitroNode,
+		paymentManager: paymentManager,
 	}
 
-	nrs.logger = logging.LoggerWithAddress(slog.Default(), *node.Address)
+	nrs.logger = logging.LoggerWithAddress(slog.Default(), *nitroNode.Address)
 	ctx, cancel := context.WithCancel(context.Background())
 	nrs.cancel = cancel
 	nrs.wg.Add(1)


### PR DESCRIPTION
Part of [Create bridge channel in go-nitro](https://www.notion.so/Create-bridge-channel-in-go-nitro-22ce80a0d8ae4edb80020a8f250ea270)
- Upgrade nitro protocol version
- Revert change to remove default TLS cert in go-nitro node CLI
- Update web-socket message ports

